### PR TITLE
Reauthentication and deleting firewall groups that are in use.

### DIFF
--- a/config/samples/unifi_v1beta1_firewallgroup.yaml
+++ b/config/samples/unifi_v1beta1_firewallgroup.yaml
@@ -9,9 +9,4 @@ spec:
   name: Test
   manualAddresses:
     - 192.168.1.153
-    - 192.168.1.154
-    - 192.168.1.155
-    - 2a01::3
-    - 2a01:0::5
-    - 2a01:2a01::/32
   # TODO(user): Add fields here

--- a/internal/unifi/unifi.go
+++ b/internal/unifi/unifi.go
@@ -7,6 +7,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"sync"
+	"strings"
 	"net/http"
 	"net/http/cookiejar"
 	"os"
@@ -78,11 +80,11 @@ func CreateUnifiClient() (*UnifiClient, error) {
 	return unifiClient, nil
 }
 
-func (s *Session) WithSession(action func(c *unifi.Client) error) error {
+func (s *UnifiClient) WithSession(action func(c *unifi.Client) error) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	err := action(s.client)
+	err := action(s.Client)
 	if err == nil {
 		return nil
 	}
@@ -94,9 +96,10 @@ func (s *Session) WithSession(action func(c *unifi.Client) error) error {
 
 		return action(s.Client)
 	}
+	return err
 }
 
-func isSessionExpired(err error) bool {
+func IsSessionExpired(err error) bool {
 	if err == nil {
 		return false
 	}


### PR DESCRIPTION
Got a bit carried away and solved two issues.

The workaround for deleting firewall groups:
If the delete fails because it's in use:
- Rename it to -deleted
- Set the object to one entry: localhost (or the ipv6 equivalent ::1)

If it's again recreated, it will be found and modified correctly.