### PR TITLE
Handle annotations in firewallgroup reconcile function

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - unifi.engen.priv.no
   resources:
   - firewallgroups

--- a/config/samples/unifi_v1beta1_firewallgroup.yaml
+++ b/config/samples/unifi_v1beta1_firewallgroup.yaml
@@ -7,6 +7,8 @@ metadata:
   name: firewallgroup-sample
 spec:
   name: Test
+  matchServicesInAllNamespaces: true
   manualAddresses:
     - 192.168.1.153
+    - 192.168.1.154
   # TODO(user): Add fields here


### PR DESCRIPTION
Handle unifi.engen.priv.no/firewall-group: <name> where name is the name of the
resource.

It will add ingress IPs from the services in ipv4 and ipv6 network object.